### PR TITLE
Remove integer validation for the model_id

### DIFF
--- a/src/Http/Controllers/LanguageController.php
+++ b/src/Http/Controllers/LanguageController.php
@@ -14,7 +14,7 @@ class LanguageController
         $request->validate([
             'lang' => 'required|string',
             'model' => 'required|string',
-            'model_id' => 'required|integer',
+            'model_id' => 'required',
         ]);
 
         $lang = UserLanguage::query()


### PR DESCRIPTION
Remove integer validation for the model_id, as it could be a string in the case of a UUID.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated validation for `model_id` parameter to accept any non-null value, enhancing flexibility in user input.
  
- **Bug Fixes**
	- Preserved existing logic for retrieving and updating `UserLanguage` models, ensuring consistent functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->