### PR TITLE
Fixed migration rollback breaking on `allow_user_lang_table => false`

### DIFF
--- a/database/migrations/2024_10_23_010712_create_user_languages_table.php
+++ b/database/migrations/2024_10_23_010712_create_user_languages_table.php
@@ -24,6 +24,6 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::drop('user_languages');
+        Schema::dropIfExists('user_languages');
     }
 };


### PR DESCRIPTION
Hi, first of all, thanks for creating this package! It looks super useful!

Fixed an issue that occurred on rollbacking the migration when having `allow_user_lang_table` set to `false`.

I chose to not use the `if` statement used in the `up` method, in case someone changed the value before doing the rollback. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved migration logic to prevent errors when dropping the `user_languages` table if it does not exist. 

This change enhances the stability of database migrations related to user languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->