### PR TITLE
Fixed instruction for trait usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ finally register the plugin on `/app/Providers/Filament/AdminPanelProvider.php`
 now on your `User.php` model or any user model add this trait
 
 ```php
-use TomatoPHP\FilamentLanguageSwitcher\Traits\InteractsWithLanguages;
+use \TomatoPHP\FilamentLanguageSwitcher\Traits\InteractsWithLanguages;
 ```
 
 now you must see the switcher and you can change language as you like


### PR DESCRIPTION
Following the README, there's a `\` missing when the user is requested to add the Trait. 

I've assumed the intended use case for the line "now on your `User.php` model or any user model add this trait" was to add the line of code to the class directly as trait and not as an import statement.

If this was not intentional, feel free to close this PR. Although in that case I'd recommend changing the line above.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Improved formatting and organization of the README file.
	- Clarified namespace resolution in the import statement for better understanding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->