### PR TITLE
Use config for default locale in LanguageMiddleware

### DIFF
--- a/src/Http/Middleware/LanguageMiddleware.php
+++ b/src/Http/Middleware/LanguageMiddleware.php
@@ -19,7 +19,7 @@ class LanguageMiddleware
             if (! empty($request->user()->lang)) {
                 app()->setLocale($request->user()->lang);
             } else {
-                app()->setLocale('en');
+                app()->setLocale(config('app.locale', 'en'));
             }
         }
 


### PR DESCRIPTION
This proposal is for apps that don't use `en` as the primary language.

This will try to retrieve the project locale from the env and fallback to `en` if the key doesn't exist.